### PR TITLE
GitHub Actions でqin-todo.yamlからhtmlを作成してGCSにアップロードする機能の実装

### DIFF
--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         node: ["12","14"]
     steps:
-      - name: checkout  # コードを取得するみたい？
-        uses: actions/checkout@feature/aopontann-github-actions
+      - name: checkout  
+        uses: actions/${{ github.repository }}@feature/aopontann-github-actions
 
       - name: node setting
         uses: actions/setup-node@v3

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node: ["12","14"]
+        node: ["14"]
     steps:
       - name: checkout
         uses: actions/checkout@v3 # これでレポジトリからコードを取得できるけど、なんでか分からん
@@ -22,17 +22,11 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - name: ls # 中身見てみる
-        run: ls -a
-
       - name: install redoc
         run: npm install -g redoc-cli
 
       - name: build OpenAPI file
         run: redoc-cli bundle ./api/qin-todo.yaml
-
-      - name: output file
-        run: cat ./redoc-static.html
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
@@ -44,4 +38,4 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: ./redoc-static.html
-          destination: qin-todo-team-l-openapi/file
+          destination: qin-todo-team-l-openapi

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         node: ["12","14"]
     steps:
-      - name: checkout  
-        uses: actions/${{ github.repository }}@feature/aopontann-github-actions
+      - name: checkout
+        uses: actions/checkout@v3
 
       - name: node setting
         uses: actions/setup-node@v3

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -19,6 +19,9 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - name: ls # 中身見てみる
+        run: ls -a
+
       - name: install redoc
         run: npm install -g redoc-cli
 

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         node: ["12","14"]
     steps:
+      - name: checkout  # コードを取得するみたい？
+        uses: actions/checkout@feature/aopontann-github-actions
+
       - name: node setting
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -15,7 +15,7 @@ jobs:
         node: ["12","14"]
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3 # これでレポジトリからコードを取得できるけど、なんでか分からん
 
       - name: node setting
         uses: actions/setup-node@v3
@@ -33,3 +33,16 @@ jobs:
 
       - name: output file
         run: cat ./redoc-static.html
+
+      # コピペ https://hatolabo.com/programming/%E3%80%90github-actions-gcs%E3%80%91githubactions%E3%81%A7cloud-storage%E3%81%AB%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%82%92%E3%82%A2%E3%83%83%E3%83%97%E3%83%AD%E3%83%BC%E3%83%89%E3%81%99%E3%82%8B
+      - uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - id: upload-file
+        uses: google-github-actions/upload-cloud-storage@main
+        with:
+          path: ./redoc-static.html
+          destination: qin-todo-team-l-openapi/file

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -34,12 +34,11 @@ jobs:
       - name: output file
         run: cat ./redoc-static.html
 
-      # コピペ https://hatolabo.com/programming/%E3%80%90github-actions-gcs%E3%80%91githubactions%E3%81%A7cloud-storage%E3%81%AB%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%82%92%E3%82%A2%E3%83%83%E3%83%97%E3%83%AD%E3%83%BC%E3%83%89%E3%81%99%E3%82%8B
-      - uses: google-github-actions/setup-gcloud@master
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v0'
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - id: upload-file
         uses: google-github-actions/upload-cloud-storage@main

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -1,0 +1,29 @@
+name: OpenAPI generate to html deploy for GCS
+
+on:
+  push:
+    branches:
+      # - master
+      - feature/aopontann-github-actions
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node: ["12","14"]
+    steps:
+      - name: node setting
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: install redoc
+        run: npm install -g redoc-cli
+
+      - name: build OpenAPI file
+        run: redoc-cli bundle ./api/qin-todo.yaml
+
+      - name: output file
+        run: cat ./redoc-static.html

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -32,7 +32,7 @@ jobs:
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v0'
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
 
       - id: upload-file
         uses: google-github-actions/upload-cloud-storage@main

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -3,8 +3,7 @@ name: OpenAPI generate to html deploy for GCS
 on:
   push:
     branches:
-      # - master
-      - feature/aopontann-github-actions
+      - develop
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sample.yaml
+++ b/.github/workflows/sample.yaml
@@ -1,0 +1,15 @@
+name: Action Sample
+
+on:
+  push:
+    branches:
+      # - master
+      - feature/aopontann-github-actions
+  workflow_dispatch:
+
+jobs:
+  print-hello-world:
+    runs-on: ubuntu-latest
+    steps:
+      - name: execute echo command
+        run: echo "Hello World!"

--- a/.github/workflows/sample.yaml
+++ b/.github/workflows/sample.yaml
@@ -1,15 +1,19 @@
+# ワークフローの名前　ワークフローの名前を name で指定できる（省略可）
 name: Action Sample
 
+# トリガーイベント　ワークフローを実行するための条件を on 以下に指定する（複数の条件を指定可能）　トリガーイベントとして、プルリクエストや特定のタグ、cronなども指定可能
 on:
   push:
     branches:
       # - master
       - feature/aopontann-github-actions
-  workflow_dispatch:
+  workflow_dispatch:  #GitHub上で手動実行
 
+# 実行する処理内容や実行環境をjobs以降に記述する。なお、1つのYAMLファイルに複数のジョブを指定可能。原則として各ジョブは並列に実行されるが、依存関係（他のジョブの終了を待つ）を設定することも可能。
 jobs:
-  print-hello-world:
-    runs-on: ubuntu-latest
+  print-hello-world:  # ジョブ名　ジョブ名には英数字と-, _のみ使用可（スペースは使用不可）
+    runs-on: ubuntu-latest  # ジョブが実行されるマシンの種類
+    # steps以降に実行する処理（タスク）を記述
     steps:
-      - name: execute echo command
+      - name: execute echo command  # タスクの名前（省略可）
         run: echo "Hello World!"

--- a/.github/workflows/sample.yaml
+++ b/.github/workflows/sample.yaml
@@ -5,8 +5,7 @@ name: Action Sample
 on:
   push:
     branches:
-      # - master
-      - feature/aopontann-github-actions
+      - master # このワークフローはサンプル用であるため、存在しないブランチを指定して実行させないようにする
   workflow_dispatch:  #GitHub上で手動実行
 
 # 実行する処理内容や実行環境をjobs以降に記述する。なお、1つのYAMLファイルに複数のジョブを指定可能。原則として各ジョブは並列に実行されるが、依存関係（他のジョブの終了を待つ）を設定することも可能。

--- a/api/qin-todo.yaml
+++ b/api/qin-todo.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   title: qin-todo
   version: '0.1'
+  description: qin-todoのAPI
 servers:
   - url: 'http://localhost:18080'
 paths:


### PR DESCRIPTION
### このプルリクでやったこと
- developにマージするとgithub actionsのワークフローが起動するようにした
- github actions で`qin-todo.yaml`からhtmlを作成して、GCSにアップロードする機能の実装をした
- OpenAPI仕様をリンクから共有できるようにした

### ちょっと気になる点など
GCSにhtmlをアップロードしても(初回アップロード以外)反映されるのが少し遅い。正確な時間は測ってないが、反映されるまで5分くらいかかる。チームで共有するときは注意した方がいいかも

### 共有リンク
https://storage.googleapis.com/qin-todo-team-l-openapi/redoc-static.html