### PR TITLE
ToDo取得機能の実装&エンドポイントの変更

### DIFF
--- a/api/qin-todo.yaml
+++ b/api/qin-todo.yaml
@@ -6,7 +6,7 @@ info:
 servers:
   - url: 'http://localhost:18080'
 paths:
-  /user:
+  /users:
     get:
       summary: ユーザー情報取得
       operationId: get-user
@@ -81,6 +81,7 @@ paths:
       tags:
         - user
       description: セッションIDを使ってユーザー情報を取得する
+    parameters: []
   /auth/login:
     post:
       summary: ログイン
@@ -406,9 +407,7 @@ paths:
                         completed:
                           type: boolean
                         execution_date:
-                          type: string
-                          minLength: 1
-                          nullable: true
+                          $ref: '#/components/schemas/execution_date'
                       required:
                         - id
                         - content
@@ -420,13 +419,21 @@ paths:
                 example-1:
                   value:
                     items:
-                      - id: id001
-                        content: 洗濯物を干す
-                        completed: true
-                        execution_date: '2019-10-06 00:00:00'
-                      - id: id002
-                        content: 買い物
+                      - id: '1'
+                        content: デモ1
                         completed: false
+                        execution_date:
+                          String: '2019-10-04 00:00:00'
+                          Valid: true
+                      - id: '2'
+                        content: デモ2
+                        completed: true
+                        execution_date:
+                          String: '2019-10-05 00:00:00'
+                          Valid: true
+                      - id: '4'
+                        content: デモ4
+                        completed: true
                         execution_date: null
         '401':
           description: セッションIDが無効である場合
@@ -731,3 +738,23 @@ paths:
       tags:
         - todos
       description: 指定されたtodo_idに紐づくToDoデータを削除する
+components:
+  schemas:
+    execution_date:
+      description: ''
+      type: object
+      x-examples:
+        example-1:
+          String: '2019-10-04 00:00:00'
+          Valid: true
+      nullable: true
+      properties:
+        String:
+          type: string
+          minLength: 1
+        Valid:
+          type: boolean
+      required:
+        - String
+        - Valid
+  securitySchemes: {}

--- a/handler/todo.go
+++ b/handler/todo.go
@@ -1,0 +1,51 @@
+package handler
+
+import (
+	"database/sql"
+
+	"github.com/aopontann/qin-todo/common"
+	"github.com/gin-gonic/gin"
+)
+
+type TodoListInfo struct {
+	Id             string `json:"id"`
+	Content        string `json:"content"`
+	Completed      bool `json:"completed"`
+	Execution_date *sql.NullString `json:"execution_date"`
+}
+
+func GetTodo(c *gin.Context) {
+	var (
+		id             string
+		content        string
+		completed      *sql.NullBool
+		execution_date *sql.NullString
+	)
+	var todoList []TodoListInfo
+
+	// middlewareで認証をして成功すると、ここでユーザーIDを取得できる
+	userId := c.MustGet("userId").(string)
+
+	// MySQLに保存されているToDo情報を取得する
+	db := common.GetDB()
+	rows, err := db.Query("SELECT id, content, completed, execution_date FROM todo_list WHERE user_id = ? AND (completed = 0 OR execution_date IS NULL OR execution_date > now())", userId)
+	if err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
+
+	defer rows.Close()
+	for rows.Next() {
+		err := rows.Scan(&id, &content, &completed, &execution_date)
+		if err != nil {
+			c.JSON(400, gin.H{"error": err.Error()})
+			return
+		}
+		todoList = append(todoList, TodoListInfo{Id: id, Content: content, Completed: completed.Bool, Execution_date: execution_date})
+	}
+
+	c.JSON(200, gin.H{
+		"items": todoList,
+	})
+
+}

--- a/routes.go
+++ b/routes.go
@@ -41,6 +41,12 @@ func InitRouter() *gin.Engine {
 		user.GET("/", handler.GetUser)
 	}
 
+	todo := r.Group("/todo")
+	{
+		todo.Use(MWGetUserID())
+		todo.GET("/", handler.GetTodo)
+	}
+
 	// 本番環境では使わない検証用パス
 	demo := r.Group("/demo")
 	{

--- a/routes.go
+++ b/routes.go
@@ -35,13 +35,13 @@ func InitRouter() *gin.Engine {
 
 	}
 
-	user := r.Group("/user")
+	user := r.Group("/users")
 	{
 		user.Use(MWGetUserID())
 		user.GET("/", handler.GetUser)
 	}
 
-	todo := r.Group("/todo")
+	todo := r.Group("/todos")
 	{
 		todo.Use(MWGetUserID())
 		todo.GET("/", handler.GetTodo)

--- a/tools/database/migrations/20220409105153_completed_columns_to_tinyint_1.sql
+++ b/tools/database/migrations/20220409105153_completed_columns_to_tinyint_1.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE todo_list MODIFY completed  TINYINT(1) unsigned DEFAULT '0';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE todo_list MODIFY completed   bit(1) NOT NULL DEFAULT false;
+-- +goose StatementEnd


### PR DESCRIPTION
### このタスクでやったこと
- ToDo取得機能の実装
  - 自分が作成したToDoのみ取得できるようにした
  - ToDo完了し、やる日が過ぎたToDoは取得できないようにした
- エンドポイント`/todo`を`/todos`に変更
- エンドポイント`/user`を`/users`に変更
- completedの型をbit(1)からtinyint(1)に変更
- execution_dateのスキーマを変更